### PR TITLE
Fixed bug that was improperly withdrawing ROAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "krill"
-version = "0.6.0-APNIC"
+version = "0.6.1-APNIC"
 dependencies = [
  "actix-service",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "krill"
-version = "0.6.0-APNIC"
+version = "0.6.1-APNIC"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"
 license = "MPL-2.0"


### PR DESCRIPTION
It's triggered by the parent updating the child's certificate resources.
This event was causing the CA to update its ROAs with an empty set of
authorizations, leading the ROAs to be withdrawn. Notice that this bug
seemed to affect only CAs configured with the RoaPerAsn grouping
strategy.